### PR TITLE
Surround object to be updated in double-quotes

### DIFF
--- a/actions/reset-workspace-owner/update_file_object.sh
+++ b/actions/reset-workspace-owner/update_file_object.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Updating ownership: $1"
 echo "  `ls -lad $1`"
-chown -cvf $2 $1
+chown -cvf $2 "$1"
 echo "Modified ownership: $1"
 echo "  `ls -lad $1`"
 echo


### PR DESCRIPTION
This should properly escape any spaces in the filename.