### PR TITLE
Adjust so that only advisories count as vulnerabilities

### DIFF
--- a/actions/drupal-security-update/action.yml
+++ b/actions/drupal-security-update/action.yml
@@ -104,7 +104,9 @@ runs:
             echo "$AUDIT_OUTPUT"
             exit 1
           fi
-          VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.advisories | to_entries | map(.value | length) | add // 0')
+        fi
+        VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.advisories | to_entries | map(.value | length) | add // 0')
+        if [ "$VULN_COUNT" -gt 0 ]; then
           echo "has_vulnerabilities=true" >> $GITHUB_OUTPUT
           echo "vulnerability_count=$VULN_COUNT" >> $GITHUB_OUTPUT
           echo "::warning::Found $VULN_COUNT security vulnerabilities in Composer dependencies"


### PR DESCRIPTION
Before this change, a project that has abandoned packages only results in has_vulnerabilities set to true but vulnerability count set to 0. Later steps then result in incorrectly reporting vulnerabilities were found requiring manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the security update check to consistently calculate vulnerability counts after validation. Previously, counts were computed only in specific conditions, potentially causing incomplete detection. This fix ensures vulnerability counts are always evaluated, providing more reliable security vulnerability reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->