### PR TITLE
Improve security update handling of newly reported issues and unavailable fix versions

### DIFF
--- a/actions/drupal-security-update/README.md
+++ b/actions/drupal-security-update/README.md
@@ -67,6 +67,7 @@ jobs:
 | `slack_bot_token` | Slack bot OAuth token for posting notifications | No | - |
 | `slack_channel_id` | Slack channel ID to post notification when PR is created | No | - |
 | `slack_errors` | If true, fail the workflow when Slack notification fails | No | `false` |
+| `package_wait_seconds` | Seconds to wait and retry if a fixed package version is not yet published | No | `300` |
 
 ## Outputs
 

--- a/actions/drupal-security-update/action.yml
+++ b/actions/drupal-security-update/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'If true, fail the workflow when Slack notification fails'
     required: false
     default: 'false'
+  package_wait_seconds:
+    description: 'Seconds to wait and retry if a fixed package version is not yet published'
+    required: false
+    default: '300'
 
 outputs:
   has_vulnerabilities:
@@ -161,6 +165,7 @@ runs:
           ```
 
           Working directory: ${{ inputs.working_directory }}
+          Package wait seconds: ${{ inputs.package_wait_seconds }}
 
           Key requirements:
           - Run validation before completing

--- a/actions/drupal-security-update/action.yml
+++ b/actions/drupal-security-update/action.yml
@@ -94,7 +94,7 @@ runs:
       run: |
         set +e
         # --no-plugins prevents Composer plugins from writing to stdout and corrupting the JSON output
-        AUDIT_OUTPUT=$(composer audit --format=json --no-plugins 2>/dev/null)
+        AUDIT_OUTPUT=$(composer audit --no-cache --format=json --no-plugins 2>/dev/null)
         AUDIT_EXIT_CODE=$?
         set -e
 

--- a/actions/drupal-security-update/instructions.md
+++ b/actions/drupal-security-update/instructions.md
@@ -11,7 +11,7 @@ Update Drupal Composer dependencies that have security vulnerabilities.
 ## Process
 
 ### 1. Identify Vulnerable Packages
-Run `composer audit --format=json` to identify packages with security advisories.
+Run `composer audit --no-cache --format=json` to identify packages with security advisories.
 
 ### 2. Filter to Direct Dependencies Only
 
@@ -47,8 +47,14 @@ composer update vendor/package --with vendor/package:1.0.1 --with-dependencies
 
 **Reminder**: Never run `composer update` on a package unless you have confirmed it exists in composer.json.
 
+#### Handle Unpublished Fixed Versions
+If the fixed version is not yet available in the package repository (i.e., `composer update` succeeds but the package version does not change, and the vulnerability persists in re-audit):
+
+1. Wait for the number of seconds specified as "Package wait seconds" in the workflow prompt, then retry the update once.
+2. If still unavailable, document in pr_body.md as "fixed version not yet published" with the advisory details and a note to re-run this workflow once the version is released.
+
 ### 4. Re-check Transitive Dependency Vulnerabilities
-After updating direct dependencies, re-run `composer audit --format=json` to check if transitive vulnerabilities were resolved as a side effect.
+After updating direct dependencies, re-run `composer audit --no-cache --format=json` to check if transitive vulnerabilities were resolved as a side effect.
 
 For any transitive vulnerability that persists:
 
@@ -66,6 +72,13 @@ For any transitive vulnerability that persists:
 3. If the update succeeds and resolves the vulnerability, include it in the PR description.
 
 4. If the update fails due to constraint conflicts (the parent package doesn't allow the fixed version), document it in pr_body.md as "requires upstream fix" and note which direct dependency needs to release an update.
+
+#### New Vulnerabilities Found in Re-audit
+If the re-audit surfaces an advisory that was **not** present in the original audit JSON provided at the start of this run:
+
+1. Perform one resolution loop using the same process as steps 2–4 for the new vulnerability.
+2. If resolved, include it in the PR description.
+3. If not resolved, document it in pr_body.md as "Additional advisory found during re-audit — not addressed in this PR" with the advisory details and reason it could not be resolved.
 
 ### 5. Handle Patch Failures
 When a package update causes a patch to fail:

--- a/actions/drupal-security-update/instructions.md
+++ b/actions/drupal-security-update/instructions.md
@@ -51,7 +51,7 @@ composer update vendor/package --with vendor/package:1.0.1 --with-dependencies
 If the fixed version is not yet available in the package repository (i.e., `composer update` succeeds but the package version does not change, and the vulnerability persists in re-audit):
 
 1. Wait for the number of seconds specified as "Package wait seconds" in the workflow prompt, then retry the update once.
-2. If still unavailable, document in pr_body.md as "fixed version not yet published" with the advisory details and a note to re-run this workflow once the version is released.
+2. If still unavailable, document in pr_body.md with an attention grabbing opening line like "❌ IMPORTANT: fixed version not yet published. This workflow must be re-run once fixed version is released to resolve the vulnerability."
 
 ### 4. Re-check Transitive Dependency Vulnerabilities
 After updating direct dependencies, re-run `composer audit --no-cache --format=json` to check if transitive vulnerabilities were resolved as a side effect.
@@ -63,15 +63,17 @@ For any transitive vulnerability that persists:
    composer why vendor/vulnerable-package
    ```
 
-2. Try updating the transitive package directly:
+2. If the vulnerability can be resolved by updating the package which requires it, update the the requiring package. Otherwise, move to the next step.
+
+3. Try updating the transitive package directly:
    ```bash
    composer update vendor/vulnerable-package
    ```
    This will update it to the latest version allowed by the parent package's constraints without modifying composer.json.
 
-3. If the update succeeds and resolves the vulnerability, include it in the PR description.
+4. If the update succeeds and resolves the vulnerability, include it in the PR description.
 
-4. If the update fails due to constraint conflicts (the parent package doesn't allow the fixed version), document it in pr_body.md as "requires upstream fix" and note which direct dependency needs to release an update.
+5. If the update fails due to constraint conflicts (the parent package doesn't allow the fixed version), document it in pr_body.md as "requires upstream fix" and note which direct dependency needs to release an update.
 
 #### New Vulnerabilities Found in Re-audit
 If the re-audit surfaces an advisory that was **not** present in the original audit JSON provided at the start of this run:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional package_wait_seconds parameter (default: 300) to allow waiting and retrying when a fixed vulnerable package version isn’t yet published.

* **Improvements**
  * Automatic wait-and-retry flow when fixes are unpublished, with guidance to re-run or document required follow-up.
  * Re-audit and resolution steps expanded to detect newly surfaced advisories, attempt fixes for transitive issues, and document unresolved cases for follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->