### PR TITLE
Fix Drupal core being skipped in security updates

### DIFF
--- a/actions/drupal-security-update/instructions.md
+++ b/actions/drupal-security-update/instructions.md
@@ -108,6 +108,14 @@ For any transitive vulnerability that persists:
 
 5. If the update fails due to constraint conflicts (the parent package doesn't allow the fixed version), document it in pr_body.md as "requires upstream fix" and note which direct dependency needs to release an update.
 
+**Note on metapackage-pinned packages (e.g. `drupal/core`):** a plain
+`composer update vendor/package` will not move a package whose version is pinned
+by a metapackage, because the metapackage's exact constraint holds it in place.
+If `drupal/core` persists as a transitive advisory here, resolve it with the
+Drupal core command from step 3
+(`composer update "drupal/core-*" --with-all-dependencies`), not
+`composer update drupal/core`.
+
 #### New Vulnerabilities Found in Re-audit
 If the re-audit surfaces an advisory that was **not** present in the original audit JSON provided at the start of this run:
 

--- a/actions/drupal-security-update/instructions.md
+++ b/actions/drupal-security-update/instructions.md
@@ -29,6 +29,16 @@ If the package is NOT found in composer.json, **DO NOT run composer update on it
 
 Transitive dependencies (packages pulled in by other packages) are handled separately in step 4 after direct dependencies are updated.
 
+#### Packages installed via a metapackage (e.g. Drupal core)
+Some advisories target a package installed transitively through a metapackage
+rather than required directly. The common case is `drupal/core`: projects
+require `drupal/core-recommended` (and usually `drupal/core-composer-scaffold`
+and `drupal/core-project-message`) but NOT `drupal/core` itself.
+
+When `composer audit` reports an advisory against `drupal/core`, do NOT skip it
+because `drupal/core` is absent from `composer.json`. Treat the `drupal/core-*`
+metapackages that ARE present as the update target (see step 3).
+
 ### 3. Update Vulnerable Direct Dependencies
 For each vulnerable package that IS in `composer.json` perform the minimal update necessary to
 resolve the advisory, even if the constraints in composer.json allow for a bigger update. There
@@ -46,6 +56,29 @@ composer update vendor/package --with vendor/package:1.0.1 --with-dependencies
 ```
 
 **Reminder**: Never run `composer update` on a package unless you have confirmed it exists in composer.json.
+
+#### Drupal core
+Drupal core is a special case. Confirm which core metapackages are present:
+```bash
+grep -E "\"drupal/core-" composer.json
+```
+Then update them together, using `--with-all-dependencies` so Composer can move
+`drupal/core` (pinned transitively by `drupal/core-recommended`) to the secure
+release:
+```bash
+composer update "drupal/core-*" --with-all-dependencies
+```
+This is the update method documented in the Drupal core release notes. Quote the
+pattern so the shell does not expand it. Updating the `drupal/core-*`
+metapackages alone with `--with-dependencies` will leave `drupal/core` behind,
+because core-recommended pins exact versions; `--with-all-dependencies` is
+required so those pinned dependencies can move.
+
+To hold core to the exact fixed version and avoid a larger minor bump, pin
+core-recommended explicitly:
+```bash
+composer update "drupal/core-*" --with drupal/core-recommended:10.6.11 --with-all-dependencies
+```
 
 #### Handle Unpublished Fixed Versions
 If the fixed version is not yet available in the package repository (i.e., `composer update` succeeds but the package version does not change, and the vulnerability persists in re-audit):


### PR DESCRIPTION
## Problem

Reported in #50: the `drupal-security-update` action leaves `drupal/core` out of the update when a core security advisory fires.

Root cause is in `actions/drupal-security-update/instructions.md` (the prompt that drives the agent):

1. **Step 2** instructs the agent to update only packages literally present in `composer.json`, gated by a `grep` for the package name. But Drupal projects do not require `drupal/core` directly; they require the metapackages `drupal/core-recommended`, `drupal/core-composer-scaffold`, and `drupal/core-project-message`. `drupal/core` is pulled in transitively. So an advisory against `drupal/core` fails the grep and the agent skips it.
2. **Step 3** only provided `--with-dependencies` command templates. Even when a core metapackage is updated, `drupal/core-recommended` pins exact versions, so core will not move without `--with-all-dependencies`.
3. **Step 4** (transitive re-audit) only ran a plain `composer update vendor/package`, which likewise cannot move `drupal/core` while core-recommended pins it. So even the fallback path would have left core behind.

## Fix

Documentation/prompt-only change to `instructions.md`:

- **Step 2:** add a "Packages installed via a metapackage" carve-out so a `drupal/core` advisory is not skipped when `drupal/core` is absent from `composer.json`; the present `drupal/core-*` metapackages are the update target.
- **Step 3:** add a "Drupal core" subsection using the Drupal-documented command:
  ```bash
  composer update "drupal/core-*" --with-all-dependencies
  ```
  with a note on why `--with-all-dependencies` (not `--with-dependencies`) is required, and a pinned variant for holding core to the exact fixed version.
- **Step 4:** add a note that a plain `composer update vendor/package` will not move a metapackage-pinned package; for `drupal/core`, point back to the Step 3 command (belt and suspenders).

This matches the update method documented in the [Drupal core release notes](https://www.drupal.org/project/drupal/releases/10.6.11).

## Notes

- No code/shell changes; this only edits the agent prompt.
- Supporting evidence in the issue: phase2/inova-public#1092 (review showing core left out).

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to handle security advisories for Drupal core when the core package isn’t directly declared, using `drupal/core-*` metapackages as update targets
  * Added verification guidance to confirm relevant core metapackages are present before proceeding
  * Provided concrete composer commands (including updating multiple core metapackages together) and notes to avoid unintended version behavior during remediation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->