### PR TITLE
Fix false negative in composer audit for Drupal security updates

### DIFF
--- a/actions/drupal-security-update/action.yml
+++ b/actions/drupal-security-update/action.yml
@@ -93,8 +93,10 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       run: |
         set +e
-        # --no-plugins prevents Composer plugins from writing to stdout and corrupting the JSON output
-        AUDIT_OUTPUT=$(composer audit --no-cache --format=json --no-plugins 2>/dev/null)
+        # Plugins MUST stay enabled: composer audit relies on them to reach Drupal's
+        # advisory source. stderr is already discarded and output is --format=json,
+        # so plugin notices cannot corrupt the captured JSON. See octane-actions#54.
+        AUDIT_OUTPUT=$(composer audit --no-cache --format=json 2>/dev/null)
         AUDIT_EXIT_CODE=$?
         set -e
 
@@ -102,12 +104,13 @@ runs:
         echo "$AUDIT_OUTPUT" >> $GITHUB_OUTPUT
         echo "GHAAJEOF" >> $GITHUB_OUTPUT
 
-        if [ $AUDIT_EXIT_CODE -ne 0 ]; then
-          if ! echo "$AUDIT_OUTPUT" | jq -e . >/dev/null 2>&1; then
-            echo "::error::composer audit did not produce valid JSON (exit code: $AUDIT_EXIT_CODE). Raw output:"
-            echo "$AUDIT_OUTPUT"
-            exit 1
-          fi
+        # composer audit exits non-zero when advisories ARE found, so a non-zero exit is
+        # normal here; only invalid JSON is a real error. Validate unconditionally so a
+        # corrupted/empty payload fails loudly instead of counting as "0 vulnerabilities".
+        if ! echo "$AUDIT_OUTPUT" | jq -e . >/dev/null 2>&1; then
+          echo "::error::composer audit did not produce valid JSON (exit code: $AUDIT_EXIT_CODE). Raw output:"
+          echo "$AUDIT_OUTPUT"
+          exit 1
         fi
         VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.advisories | to_entries | map(.value | length) | add // 0')
         if [ "$VULN_COUNT" -gt 0 ]; then


### PR DESCRIPTION
## Summary

The weekly Drupal security-update flow silently failed to open PRs for the three Drupal core advisories published 2026-07-15 (SA-CORE-2026-010/011/012). It did not error; it produced a false negative. Root cause: the `--no-plugins` flag on the `composer audit` detection command in `actions/drupal-security-update/action.yml`.

`--no-plugins` disables the Composer plugin(s) that `composer audit` needs to reach Drupal's advisory source, so audit reports zero advisories even when real CVEs are pending, and the PR-creation path is skipped.

## Changes

1. **Remove `--no-plugins`** from the detection command. The flag was added in `c7e373c` to "prevent plugins from corrupting the JSON output", but stderr is already discarded (`2>/dev/null`) and output is `--format=json`, so plugin notices cannot corrupt the captured JSON. The flag guarded a problem that did not exist while disabling detection.
2. **Validate the audit JSON unconditionally.** Previously the JSON-validity check ran only on a non-zero exit code. Now it always runs, so a corrupted or empty payload fails the step loudly instead of silently counting as "0 vulnerabilities". (`composer audit` exits non-zero when advisories ARE found, so a non-zero exit is the normal detection case.)

## Evidence

- Maintainer repro (issue #54, comment 2): plain `composer audit` finds all 3 CVEs; `composer audit --no-plugins` finds none.
- CI logs (`phase2/mastercard-mbi` run 29448999435, and identical rerun 29515363733): the action's own `composer install` step logs "Found 3 security vulnerability advisories affecting 1 package", while the next `composer audit --no-plugins` step logs "No security vulnerabilities found" -> `has_vulnerabilities=false` -> PR skipped.

## Blast radius / rollout

Every consumer workflow pins `uses: .../drupal-security-update@main`, so merging this propagates to all consumer repos on their next run. Re-dispatching to catch the already-published SA-CORE-2026-010/011/012 across repos is a separate, deliberately-gated operational step (the `phase2/devcloud-auto` monitor tracks seen advisory GUIDs, so a plain cron run may not re-fire them).

## Testing

- Level 1 (container): reproduce `--no-plugins` -> 0 advisories, confirm the fix -> 3 advisories with valid JSON on stdout, in `ghcr.io/phase2/docker-cli:php8.4`.
- Level 2 (end to end): dispatch this branch against `ddev-octane-test` (dry-run then full) and confirm a security PR is opened, then clean up.

Results will be posted as a comment.

## Notes

- Complementary to #51 (which fixes Claude's `instructions.md` skipping `drupal/core` as a metapackage transitive). Different file, no conflict; both are needed for a real core CVE to be handled end to end.

Refs #54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security audit reliability by keeping Composer plugins enabled during scans.
  * Added consistent validation of audit results and clearer error details when invalid output is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->