### PR TITLE
Surface composer audit stderr on JSON-validation failure

### DIFF
--- a/actions/drupal-security-update/action.yml
+++ b/actions/drupal-security-update/action.yml
@@ -94,9 +94,11 @@ runs:
       run: |
         set +e
         # Plugins MUST stay enabled: composer audit relies on them to reach Drupal's
-        # advisory source. stderr is already discarded and output is --format=json,
-        # so plugin notices cannot corrupt the captured JSON. See octane-actions#54.
-        AUDIT_OUTPUT=$(composer audit --no-cache --format=json 2>/dev/null)
+        # advisory source. Capture stderr separately (kept out of the JSON on stdout,
+        # but not discarded) so failure diagnostics survive for the error path below.
+        # See octane-actions#54.
+        AUDIT_STDERR="$(mktemp)"
+        AUDIT_OUTPUT=$(composer audit --no-cache --format=json 2>"$AUDIT_STDERR")
         AUDIT_EXIT_CODE=$?
         set -e
 
@@ -106,12 +108,17 @@ runs:
 
         # composer audit exits non-zero when advisories ARE found, so a non-zero exit is
         # normal here; only invalid JSON is a real error. Validate unconditionally so a
-        # corrupted/empty payload fails loudly instead of counting as "0 vulnerabilities".
+        # corrupted/empty payload (e.g. an unreachable advisory source) fails loudly
+        # instead of counting as "0 vulnerabilities".
         if ! echo "$AUDIT_OUTPUT" | jq -e . >/dev/null 2>&1; then
           echo "::error::composer audit did not produce valid JSON (exit code: $AUDIT_EXIT_CODE). Raw output:"
           echo "$AUDIT_OUTPUT"
+          echo "composer audit stderr:"
+          cat "$AUDIT_STDERR"
+          rm -f "$AUDIT_STDERR"
           exit 1
         fi
+        rm -f "$AUDIT_STDERR"
         VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.advisories | to_entries | map(.value | length) | add // 0')
         if [ "$VULN_COUNT" -gt 0 ]; then
           echo "has_vulnerabilities=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Follow-up to #55 (merged). When `composer audit` fails hard, for example an unreachable advisory source returns exit 100 with no JSON, the current error path prints an empty `Raw output:` because stderr is discarded via `2>/dev/null`. This captures stderr to a temp file and prints it in the invalid-JSON error branch, so the real cause is visible, while stdout stays clean `--format=json` for parsing.

This addresses CodeRabbit's stderr-capture suggestion on #55, which came in just after #55 was merged.

## E2E validated

Verified in the production runner image `ghcr.io/phase2/docker-cli:php8.4` (Composer 2.10):

- **Normal case**: audit still returns the 3 pending Drupal core advisories as valid JSON (`VULN_COUNT=3`), so the update/PR path proceeds unchanged.
- **Failure case** (advisory source unreachable): the step now fails closed **and** prints the real diagnostic (`curl error 6 ... Could not resolve host`) instead of an empty `Raw output:` block.

The end-to-end security-update flow (detect &rarr; Claude update &rarr; PR) was also validated on a real repo during #54/#55 verification: a live run detected all three advisories and opened a correct `drupal/core` 11.3.13 &rarr; 11.3.14 PR.

## Note on the related CodeRabbit comment

CodeRabbit also suggested failing on a non-empty `unreachable-repositories` field. That is already covered: on Composer 2.10 an unreachable repo makes `composer audit` fail hard (exit 100, non-JSON), which the unconditional `jq -e .` validation from #55 catches. The `unreachable-repositories` key is not present in this version's audit output unless `--ignore-unreachable` is passed, which we do not. No code change made for that one.

Refs #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Composer audit failure diagnostics by displaying both raw output and error details when results cannot be parsed.
  * Ensured temporary diagnostic data is cleaned up after both successful and failed audit runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->