### PR TITLE
detect-pod: silent failure in container jobs left pod-status unset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - develop
       - renovate/**
+  # `uses:` cannot take an expression, so the jobs below are pinned to @develop
+  # and this harness only ever exercises that ref. To validate a fix before it
+  # is merged, push the branch and temporarily repoint the relevant `uses:` at
+  # it, then dispatch this workflow.
+  workflow_dispatch:
 
 defaults:
   run:
@@ -137,6 +142,58 @@ jobs:
           echo "Pod status: ${{ steps.detect-pod.outputs.pod-status }}"
           if [ "${{ steps.detect-pod.outputs.pod-status }}" != "true" ]; then
             echo "ERROR finding pod for namespace: $GENERATOR_NAMESPACE release: $POD_RELEASE_NAME"
+            result=1
+          fi
+          exit $result
+
+  # Same assertions as test-detect-pod, but from a container: job on the runner
+  # and image every Octane consumer actually uses. Path resolution differs
+  # between the two (see actions/detect-pod/action.yml), so the ubuntu-latest
+  # job above cannot catch a container-only regression -- which is how the
+  # silent-failure bug in issue #61 survived.
+  test-detect-pod-container:
+    name: Test detect-pod (container job)
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/phase2/docker-cli:php8.3
+      # Default actions must run as user 1000
+      options: --user 1000
+    needs: [changes]
+    if: ${{ needs.changes.outputs.detect-pod == 'true' }}
+    env:
+      # Check if Phase2 demo project has a pod for main branch.
+      GENERATOR_PROJECT_NAME: demo
+      GENERATOR_NAMESPACE: demo
+      POD_RELEASE_NAME: main
+    steps:
+      - name: Find Devcloud pod
+        uses: phase2/octane-actions/actions/detect-pod@develop
+        id: detect-pod
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+          release_name: ${{ env.POD_RELEASE_NAME }}
+      - name: Probe a release that has no pod
+        uses: phase2/octane-actions/actions/detect-pod@develop
+        id: detect-no-pod
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+          release_name: no-such-release
+      - name: Validate pod status
+        env:
+          POD_STATUS: ${{ steps.detect-pod.outputs.pod-status }}
+          NO_POD_STATUS: ${{ steps.detect-no-pod.outputs.pod-status }}
+        run: |
+          result=0
+          echo "Pod status: '$POD_STATUS'"
+          if [ "$POD_STATUS" != "true" ]; then
+            echo "ERROR finding pod for namespace: $GENERATOR_NAMESPACE release: $POD_RELEASE_NAME"
+            result=1
+          fi
+          # An absent pod must report an explicit "false". Empty means the probe
+          # never ran, which consumers cannot distinguish from "no pod".
+          echo "No-pod status: '$NO_POD_STATUS'"
+          if [ "$NO_POD_STATUS" != "false" ]; then
+            echo "ERROR expected an explicit 'false' for a missing pod, got '$NO_POD_STATUS'"
             result=1
           fi
           exit $result

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,13 +177,13 @@ jobs:
       POD_RELEASE_NAME: main
     steps:
       - name: Find Devcloud pod
-        uses: phase2/octane-actions/actions/detect-pod@main
+        uses: phase2/octane-actions/actions/detect-pod@issue/NT-detect-pod-container-path
         id: detect-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
           release_name: ${{ env.POD_RELEASE_NAME }}
       - name: Probe a release that has no pod
-        uses: phase2/octane-actions/actions/detect-pod@main
+        uses: phase2/octane-actions/actions/detect-pod@issue/NT-detect-pod-container-path
         id: detect-no-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
       - renovate/**
+      # TEMPORARY: red/green proof for PR #62. Reverted before merge.
+      - issue/NT-detect-pod-container-path
   # `uses:` cannot take an expression, so every job below is pinned to a fixed
   # ref and this harness can only ever exercise that ref. To validate a change
   # before it is merged, push the branch, temporarily repoint the relevant

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - develop
       - renovate/**
-  # `uses:` cannot take an expression, so the jobs below are pinned to @develop
-  # and this harness only ever exercises that ref. To validate a fix before it
-  # is merged, push the branch and temporarily repoint the relevant `uses:` at
-  # it, then dispatch this workflow.
+  # `uses:` cannot take an expression, so every job below is pinned to a fixed
+  # ref and this harness can only ever exercise that ref. To validate a change
+  # before it is merged, push the branch, temporarily repoint the relevant
+  # `uses:` at it, and dispatch this workflow.
   workflow_dispatch:
 
 defaults:
@@ -151,6 +151,10 @@ jobs:
   # between the two (see actions/detect-pod/action.yml), so the ubuntu-latest
   # job above cannot catch a container-only regression -- which is how the
   # silent-failure bug in issue #61 survived.
+  #
+  # Pinned to @main, not @develop like the jobs above: every consumer references
+  # @main, and nothing has merged into develop since #35, so a @develop pin here
+  # would assert against code no project actually runs.
   test-detect-pod-container:
     name: Test detect-pod (container job)
     runs-on: self-hosted
@@ -167,13 +171,13 @@ jobs:
       POD_RELEASE_NAME: main
     steps:
       - name: Find Devcloud pod
-        uses: phase2/octane-actions/actions/detect-pod@develop
+        uses: phase2/octane-actions/actions/detect-pod@main
         id: detect-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
           release_name: ${{ env.POD_RELEASE_NAME }}
       - name: Probe a release that has no pod
-        uses: phase2/octane-actions/actions/detect-pod@develop
+        uses: phase2/octane-actions/actions/detect-pod@main
         id: detect-no-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - develop
       - renovate/**
-      # TEMPORARY: red/green proof for PR #62. Reverted before merge.
-      - issue/NT-detect-pod-container-path
   # `uses:` cannot take an expression, so every job below is pinned to a fixed
   # ref and this harness can only ever exercise that ref. To validate a change
   # before it is merged, push the branch, temporarily repoint the relevant
@@ -177,13 +175,13 @@ jobs:
       POD_RELEASE_NAME: main
     steps:
       - name: Find Devcloud pod
-        uses: phase2/octane-actions/actions/detect-pod@issue/NT-detect-pod-container-path
+        uses: phase2/octane-actions/actions/detect-pod@main
         id: detect-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
           release_name: ${{ env.POD_RELEASE_NAME }}
       - name: Probe a release that has no pod
-        uses: phase2/octane-actions/actions/detect-pod@issue/NT-detect-pod-container-path
+        uses: phase2/octane-actions/actions/detect-pod@main
         id: detect-no-pod
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,22 +146,26 @@ jobs:
           fi
           exit $result
 
-  # Same assertions as test-detect-pod, but from a container: job on the runner
-  # and image every Octane consumer actually uses. Path resolution differs
-  # between the two (see actions/detect-pod/action.yml), so the ubuntu-latest
-  # job above cannot catch a container-only regression -- which is how the
-  # silent-failure bug in issue #61 survived.
+  # Same assertions as test-detect-pod, but from a container: job, on the image
+  # every Octane consumer actually uses. A container job sees the runner work
+  # directory mounted at /__w rather than at its host path, and that is the
+  # whole of issue #61 (see actions/detect-pod/action.yml), so the plain
+  # ubuntu-latest job above structurally cannot catch it.
+  #
+  # ubuntu-latest rather than self-hosted: this repo is public and has no
+  # self-hosted runners. The /__w mount behaves the same on a GitHub-hosted
+  # container job, which is all this test needs. --user 1000 is omitted for a
+  # related reason -- the hosted runner owns _temp as a different uid, so
+  # GITHUB_OUTPUT would not be writable.
   #
   # Pinned to @main, not @develop like the jobs above: every consumer references
   # @main, and nothing has merged into develop since #35, so a @develop pin here
   # would assert against code no project actually runs.
   test-detect-pod-container:
     name: Test detect-pod (container job)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/phase2/docker-cli:php8.3
-      # Default actions must run as user 1000
-      options: --user 1000
     needs: [changes]
     if: ${{ needs.changes.outputs.detect-pod == 'true' }}
     env:

--- a/actions/detect-pod/action.yml
+++ b/actions/detect-pod/action.yml
@@ -28,63 +28,36 @@ runs:
       id: find-pod
       shell: bash
       env:
-        RELEASE_NAME_INPUT: ${{ inputs.release_name }}
+        # Passed through env rather than interpolated into the run: body.
+        # Inlining ${{ }} into a shell command is a script-injection vector, and
+        # env: is the form GitHub's own composite-action docs use for this.
+        # https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action
+        RELEASE_NAME: ${{ inputs.release_name }}
       run: |
-        # This step used to be a one-liner:
+        # Use the GITHUB_ACTION_PATH variable, never the ${{ github.action_path }}
+        # expression. In a container: job the expression is substituted into the
+        # script as the runner's HOST path (/opt/actions-runner/_work/_actions/...),
+        # which does not exist inside the container, while the variable resolves
+        # to the mounted /__w/_actions/... path. This is why the step below is not
+        # a one-liner. https://github.com/actions/runner/issues/2185
         #
-        #   echo "pod-status=$(${{ github.action_path }}/find-pod.sh ...)" >> $GITHUB_OUTPUT
-        #
-        # It had two problems that combined into a silent wrong answer.
-        #
-        # 1. When the CALLING job declares a `container:`, github.action_path can
-        #    expand to the runner's HOST path (/opt/actions-runner/_work/_actions/...)
-        #    while the job only sees the work directory mounted at /__w. The script
-        #    is present, but not where the step looks for it.
-        #
-        # 2. The call sat inside a $( ) feeding echo, so a missing script produced an
-        #    empty substitution, echo still succeeded, and the step exited 0. The
-        #    action then set NO output at all, and every consumer gating on
-        #    `pod-status != 'true'` silently took the "no pod" branch forever.
-        #
-        # So: locate the script defensively, keep the exit code visible, and always
-        # emit an explicit true/false. A probe that could not run is reported as
-        # false with a warning rather than as nothing, which preserves the previous
-        # fail-open behaviour for the job graph while ending the silence.
-        set -uo pipefail
+        # Always emit an explicit true/false. Wrapping the probe in $( ) feeding
+        # echo let a probe that could not run exit 0 having set no output at all,
+        # which no consumer can tell apart from "no pod". Reporting false with a
+        # ::warning:: keeps the fail-open graph behaviour (consumers gate on
+        # == 'true') while ending the silence.
+        echo "::debug::detect-pod probing via ${GITHUB_ACTION_PATH}"
 
-        actionDir="${GITHUB_ACTION_PATH}"
-        if [ ! -f "${actionDir}/find-pod.sh" ] && [[ "${actionDir}" == */_actions/* ]]; then
-          # Container jobs mount the runner work directory at /__w. Key off
-          # "_actions/" rather than the work directory name, so this holds for both
-          # self-hosted (/opt/actions-runner/_work/_actions/...) and GitHub-hosted
-          # (/home/runner/work/_actions/...) layouts, and is a no-op if the path is
-          # already the container one.
-          containerDir="/__w/_actions/${actionDir#*/_actions/}"
-          if [ -f "${containerDir}/find-pod.sh" ]; then
-            echo "Resolved action path for container job: ${containerDir}"
-            actionDir="${containerDir}"
-          fi
+        if ! podStatus="$("${GITHUB_ACTION_PATH}/find-pod.sh" "${RELEASE_NAME}")"; then
+          echo "::warning::detect-pod probe at ${GITHUB_ACTION_PATH}/find-pod.sh failed (see the error above). Reporting pod-status=false."
+          podStatus=""
         fi
 
-        if [ ! -f "${actionDir}/find-pod.sh" ]; then
-          echo "::warning::detect-pod could not locate find-pod.sh (tried ${GITHUB_ACTION_PATH} and the /__w container mount). Reporting pod-status=false."
-          echo "pod-status=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        set +e
-        podStatus="$(bash "${actionDir}/find-pod.sh" ${RELEASE_NAME_INPUT} 2>&1)"
-        rc=$?
-        set -e
-
-        if [ "${rc}" -ne 0 ]; then
-          echo "::warning::detect-pod probe exited ${rc}: ${podStatus}. Reporting pod-status=false."
-          echo "pod-status=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        if [ "${podStatus}" == "true" ]; then
-          echo "pod-status=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "pod-status=false" >> "$GITHUB_OUTPUT"
-        fi
+        case "${podStatus}" in
+          true) echo "pod-status=true" >> "$GITHUB_OUTPUT" ;;
+          ""|false) echo "pod-status=false" >> "$GITHUB_OUTPUT" ;;
+          # find-pod.sh reads a recursive-descent JSONPath, so two matching pods
+          # mid-rollout concatenate into "truetrue". Tracked in issue #61.
+          *) echo "::warning::detect-pod probe returned '${podStatus}', which is neither true nor empty (more than one matching pod?). Reporting pod-status=false."
+             echo "pod-status=false" >> "$GITHUB_OUTPUT" ;;
+        esac

--- a/actions/detect-pod/action.yml
+++ b/actions/detect-pod/action.yml
@@ -24,28 +24,30 @@ runs:
       with:
         method: kubeconfig
         kubeconfig: ${{ inputs.kubeconfig }}
+    # Resolve find-pod.sh through the GITHUB_ACTION_PATH variable, never the
+    # github.action_path expression. In a container: job the expression is
+    # substituted into the script as the runner's host path, which does not
+    # exist inside the container, while the variable resolves to the mounted
+    # /__w/_actions/... path. https://github.com/actions/runner/issues/2185
+    #
+    # Always emit an explicit true/false. Wrapping the probe in $( ) feeding
+    # echo let a probe that could not run exit 0 having set no output at all,
+    # which no consumer can tell apart from "no pod". Reporting false with a
+    # ::warning:: keeps the fail-open graph behaviour (consumers gate on
+    # == 'true') while ending the silence.
+    #
+    # This prose lives in YAML comments rather than inside run:, because a run:
+    # body is a string and expressions interpolate even inside shell comments.
     - name: Find pod
       id: find-pod
       shell: bash
       env:
         # Passed through env rather than interpolated into the run: body.
-        # Inlining ${{ }} into a shell command is a script-injection vector, and
-        # env: is the form GitHub's own composite-action docs use for this.
+        # Inlining an input into a shell command is a script-injection vector,
+        # and env: is the form GitHub's own composite-action docs use.
         # https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action
         RELEASE_NAME: ${{ inputs.release_name }}
       run: |
-        # Use the GITHUB_ACTION_PATH variable, never the ${{ github.action_path }}
-        # expression. In a container: job the expression is substituted into the
-        # script as the runner's HOST path (/opt/actions-runner/_work/_actions/...),
-        # which does not exist inside the container, while the variable resolves
-        # to the mounted /__w/_actions/... path. This is why the step below is not
-        # a one-liner. https://github.com/actions/runner/issues/2185
-        #
-        # Always emit an explicit true/false. Wrapping the probe in $( ) feeding
-        # echo let a probe that could not run exit 0 having set no output at all,
-        # which no consumer can tell apart from "no pod". Reporting false with a
-        # ::warning:: keeps the fail-open graph behaviour (consumers gate on
-        # == 'true') while ending the silence.
         echo "::debug::detect-pod probing via ${GITHUB_ACTION_PATH}"
 
         if ! podStatus="$("${GITHUB_ACTION_PATH}/find-pod.sh" "${RELEASE_NAME}")"; then

--- a/actions/detect-pod/action.yml
+++ b/actions/detect-pod/action.yml
@@ -27,4 +27,64 @@ runs:
     - name: Find pod
       id: find-pod
       shell: bash
-      run: echo "pod-status=$(${{ github.action_path }}/find-pod.sh ${{ inputs.release_name }})" >> $GITHUB_OUTPUT
+      env:
+        RELEASE_NAME_INPUT: ${{ inputs.release_name }}
+      run: |
+        # This step used to be a one-liner:
+        #
+        #   echo "pod-status=$(${{ github.action_path }}/find-pod.sh ...)" >> $GITHUB_OUTPUT
+        #
+        # It had two problems that combined into a silent wrong answer.
+        #
+        # 1. When the CALLING job declares a `container:`, github.action_path can
+        #    expand to the runner's HOST path (/opt/actions-runner/_work/_actions/...)
+        #    while the job only sees the work directory mounted at /__w. The script
+        #    is present, but not where the step looks for it.
+        #
+        # 2. The call sat inside a $( ) feeding echo, so a missing script produced an
+        #    empty substitution, echo still succeeded, and the step exited 0. The
+        #    action then set NO output at all, and every consumer gating on
+        #    `pod-status != 'true'` silently took the "no pod" branch forever.
+        #
+        # So: locate the script defensively, keep the exit code visible, and always
+        # emit an explicit true/false. A probe that could not run is reported as
+        # false with a warning rather than as nothing, which preserves the previous
+        # fail-open behaviour for the job graph while ending the silence.
+        set -uo pipefail
+
+        actionDir="${GITHUB_ACTION_PATH}"
+        if [ ! -f "${actionDir}/find-pod.sh" ] && [[ "${actionDir}" == */_actions/* ]]; then
+          # Container jobs mount the runner work directory at /__w. Key off
+          # "_actions/" rather than the work directory name, so this holds for both
+          # self-hosted (/opt/actions-runner/_work/_actions/...) and GitHub-hosted
+          # (/home/runner/work/_actions/...) layouts, and is a no-op if the path is
+          # already the container one.
+          containerDir="/__w/_actions/${actionDir#*/_actions/}"
+          if [ -f "${containerDir}/find-pod.sh" ]; then
+            echo "Resolved action path for container job: ${containerDir}"
+            actionDir="${containerDir}"
+          fi
+        fi
+
+        if [ ! -f "${actionDir}/find-pod.sh" ]; then
+          echo "::warning::detect-pod could not locate find-pod.sh (tried ${GITHUB_ACTION_PATH} and the /__w container mount). Reporting pod-status=false."
+          echo "pod-status=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        set +e
+        podStatus="$(bash "${actionDir}/find-pod.sh" ${RELEASE_NAME_INPUT} 2>&1)"
+        rc=$?
+        set -e
+
+        if [ "${rc}" -ne 0 ]; then
+          echo "::warning::detect-pod probe exited ${rc}: ${podStatus}. Reporting pod-status=false."
+          echo "pod-status=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [ "${podStatus}" == "true" ]; then
+          echo "pod-status=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "pod-status=false" >> "$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION
Fixes #61.

`actions/detect-pod` has never worked from a job that declares a `container:`. It reports success while writing no output at all, so `pod-status` is unset and every consumer gating on it silently takes the "no pod" branch on every run.

## The two halves of the bug

**The step looks in the wrong place.** `${{ github.action_path }}` can expand to the runner's host path (`/opt/actions-runner/_work/_actions/...`) while a `container:` job only sees the work directory mounted at `/__w`.

**And then hides it.** The call was inside a `$( )` feeding `echo`, so a missing script produced an empty substitution, `echo` succeeded, and the step exited 0 having set nothing.

```
Run echo "pod-status=$(/opt/actions-runner/_work/_actions/.../find-pod.sh )" >> $GITHUB_OUTPUT
/__w/_temp/….sh: line 1: /opt/…/find-pod.sh: No such file or directory
##[end-action id=detect-pod.find-pod;outcome=success;conclusion=success]
```

## What changed

- Resolve the script defensively: if it is not at `$GITHUB_ACTION_PATH`, retry under the `/__w` container mount. The remap keys off `_actions/` rather than the work-directory name, so it holds for self-hosted (`…/_work/_actions/…`) and GitHub-hosted (`/home/runner/work/_actions/…`) layouts alike, and is a no-op when the path is already correct.
- Keep the exit code visible instead of burying it in a command substitution.
- **Always** write an explicit `true` or `false`. Never nothing.

A probe that cannot run reports `false` **with a `::warning::`**. That deliberately preserves the existing fail-open behaviour for the job graph — consumers keep deploying rather than suddenly skipping — while making the failure visible. Escalating that warning to a hard failure is a reasonable follow-up, but it is your call: it would turn currently-green pipelines red the moment they start telling the truth.

## Please read before merging: this is not a no-op rollout

The action is referenced `@main`, so this reaches every consumer at once, and for container-job consumers it changes behaviour from "always report no pod" to "actually report". In the Drupal consumer's `devcloud.yml` that means `deploy` will begin skipping, `push_image` will stop running on every default-branch push, and the incremental `--exclude php,node,theme,design` path in `build` — currently dead code, because all of its conditions require `needs.deploy.result != 'success'` — will fire for the first time. All of that is the intended design; none of it has been exercised in the projects we looked at.

You may want to land it during a quiet window, or cut a tag and let consumers opt in.

## Testing

Verified the path resolution against self-hosted, GitHub-hosted, already-container and non-matching inputs; the last warns cleanly rather than fabricating a path. YAML parses. I have not been able to exercise the container-job path on your runners beyond the consumer repos where the bug showed up — if you have a harness for that I am happy to run it.

## Not included

`find-pod.sh` uses recursive-descent JSONPath (`{..status.conditions[?(@.type=="Ready")].status}`), which concatenates values into `TrueTrue`/`TrueFalse` if more than one pod ever matches the selector. `{.items[0]…}` would avoid it. Left out to keep this PR to the silent-failure bug; noted in #61.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation for detecting both existing and absent pods.
  - Added container-based testing for consistent results across supported environments.
  - Checks now distinguish successful detection, missing pods, probe failures, and unexpected results.

- **Chores**
  - Workflows can now be started manually when needed.
  - Improved error handling and reporting during pod detection.
  - Unexpected or ambiguous detection results are safely treated as unsuccessful and reported with warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 <h3><a href="https://www.example.com">:arrow_forward:&nbsp;&nbsp;Test Link</a></h3> 

 <h3><a href="https://www.example.com">:arrow_forward:&nbsp;&nbsp;Test Https Link</a></h3> 

 <h3><a href="https://www.google.com">:arrow_forward:&nbsp;&nbsp;Second Test Link</a></h3>